### PR TITLE
Align content recommendation params

### DIFF
--- a/routes/learning_algorithm_routes.py
+++ b/routes/learning_algorithm_routes.py
@@ -20,10 +20,12 @@ def get_content_recommendations():
         user_id = request.args.get("user_id", "default_user")
         content_type = request.args.get("type", "general")
         platform = request.args.get("platform", "instagram")
+        topic = request.args.get("topic")
         result = learning_algorithm_service.generate_content_recommendations(
             user_id=user_id,
             content_type=content_type,
             platform=platform,
+            topic=topic,
         )
         return jsonify(result)
     except Exception as exc:

--- a/services/learning_algorithm_service.py
+++ b/services/learning_algorithm_service.py
@@ -7,6 +7,7 @@ analysis service to score the generated content.
 """
 
 import random
+from typing import Optional
 
 from models.social_media import TrainingData, db
 from services.seo_service import seo_service
@@ -16,7 +17,11 @@ class LearningAlgorithmService:
     """Service for generating new, SEO‑optimized content recommendations."""
 
     def generate_content_recommendations(
-        self, user_id: str, content_type: str, platform: str
+        self,
+        user_id: str,
+        content_type: str,
+        platform: str,
+        topic: Optional[str] = None,
     ) -> dict:
         """Generate content recommendations based on a topic and learned brand voice."""
         # Fetch training examples for the specific user and content type
@@ -39,8 +44,8 @@ class LearningAlgorithmService:
         for i in range(3):
             base_example = random.choice(training_examples)
             focus = f"Variation {i + 1} based on your '{base_example.post_type}' style"
-            topic = f"A new post about {content_type.replace('_', ' ')}"
-            new_content = f"{topic}.\n\n(Inspired by your post: '{base_example.content[:50]}...')"
+            topic_line = topic or f"A new post about {content_type.replace('_', ' ')}"
+            new_content = f"{topic_line}.\n\n(Inspired by your post: '{base_example.content[:50]}...')"
             seo_analysis = seo_service.analyze_content(new_content)
 
             recommendations.append(

--- a/static/js/social-media-automation.js
+++ b/static/js/social-media-automation.js
@@ -165,6 +165,7 @@ class ContentPlatform {
     async generateContent() {
         const topicInput = document.getElementById('generator-topic');
         const typeSelect = document.getElementById('generator-type');
+        const platformSelect = document.getElementById('generator-platform');
         const generateButton = document.getElementById('generate-content-btn');
         const resultsContainer = document.getElementById('generator-results');
         if (!topicInput || !topicInput.value.trim()) {
@@ -175,7 +176,8 @@ class ContentPlatform {
         generateButton.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Generating...';
         resultsContainer.innerHTML = '<div class="text-center text-gray-500 p-4">Generating content, please wait...</div>';
         try {
-            const response = await fetch(`${this.apiBase}/learning/content-recommendations?topic=${encodeURIComponent(topicInput.value)}&content_type=${typeSelect.value}`);
+            const platformParam = platformSelect ? `&platform=${encodeURIComponent(platformSelect.value)}` : '';
+            const response = await fetch(`${this.apiBase}/learning/content-recommendations?type=${encodeURIComponent(typeSelect.value)}&topic=${encodeURIComponent(topicInput.value)}${platformParam}`);
             const result = await response.json();
             if (response.ok && result.success) {
                 this.displayResults(result);


### PR DESCRIPTION
## Summary
- Generate content requests now pass `type`, optional `platform`, and topic to backend
- Learning algorithm route/service accept a `topic` parameter for recommendations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5c7d30fb8832f900b03bc338fd5a8